### PR TITLE
[feature] creating routes and initial page.tsx for routes

### DIFF
--- a/src/app/(afterLogin)/[username]/page.tsx
+++ b/src/app/(afterLogin)/[username]/page.tsx
@@ -1,0 +1,16 @@
+import { useParams } from "next/navigation";
+
+export default function UserPage() {
+  // useParams 훅으로 동적 세그먼트 가져오기
+  const params = useParams();
+  const { username } = params as { username?: string };
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>User Page</h1>
+      <p>
+        방문한 사용자: <strong>{username || "username 없음"}</strong>
+      </p>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/[username]/status/[id]/page.tsx
+++ b/src/app/(afterLogin)/[username]/status/[id]/page.tsx
@@ -1,0 +1,37 @@
+import { useParams } from "next/navigation";
+
+export default function StatusPage() {
+  // useParams 훅으로 URL 동적 세그먼트 가져오기
+  const params = useParams();
+  const { username, id } = params as {
+    username?: string;
+    id?: string;
+  };
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>유저의 트윗</h1>
+      <p>
+        여기서는 <strong>{username || "유저 없음"}</strong>의 특정 id 트윗을
+        확인합니다.
+      </p>
+
+      {/* URL 파라미터 확인용 */}
+      <div
+        style={{
+          marginTop: "2rem",
+          borderTop: "1px solid #ccc",
+          paddingTop: "1rem",
+        }}
+      >
+        <h3>URL 파라미터</h3>
+        <p>
+          <strong>Username:</strong> {username || "없음"}
+        </p>
+        <p>
+          <strong>ID:</strong> {id || "없음"}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/compose/tweet/page.tsx
+++ b/src/app/(afterLogin)/compose/tweet/page.tsx
@@ -1,0 +1,8 @@
+export default function TweetPage() {
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>compose tweet Page</h1>
+      <p>여기는 트윗 작성 페이지입니다.</p>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/explore/page.tsx
+++ b/src/app/(afterLogin)/explore/page.tsx
@@ -1,0 +1,8 @@
+export default function ExplorePage() {
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Explore Page</h1>
+      <p>여기는 탐색 페이지입니다.</p>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/home/page.tsx
+++ b/src/app/(afterLogin)/home/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Home Page</h1>
+      <p>여기는 홈 타임라인 페이지입니다.</p>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/layout.tsx
+++ b/src/app/(afterLogin)/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+};
+
+export default function AfterLoginLayout({ children }: Props) {
+  return <div>애프터 로그인 {children}</div>;
+}

--- a/src/app/(afterLogin)/messages/page.tsx
+++ b/src/app/(afterLogin)/messages/page.tsx
@@ -1,0 +1,8 @@
+export default function MessagesPage() {
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Messages Page</h1>
+      <p>여기는 메세지 페이지입니다.</p>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/search/page.tsx
+++ b/src/app/(afterLogin)/search/page.tsx
@@ -1,0 +1,8 @@
+export default function SearchPage() {
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Search Page</h1>
+      <p>여기는 검색 페이지입니다.</p>
+    </div>
+  );
+}

--- a/src/app/(beforeLogin)/i/flow/login/page.tsx
+++ b/src/app/(beforeLogin)/i/flow/login/page.tsx
@@ -1,0 +1,8 @@
+export default function LoginPage() {
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Login Page</h1>
+      <p>여기는 로그인 페이지입니다.</p>
+    </div>
+  );
+}

--- a/src/app/(beforeLogin)/i/flow/signup/page.tsx
+++ b/src/app/(beforeLogin)/i/flow/signup/page.tsx
@@ -1,0 +1,8 @@
+export default function SignupPage() {
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Sign up Page</h1>
+      <p>여기는 회원가입 페이지입니다.</p>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
+        <div>루트 레이아웃</div>
         {children}
       </body>
     </html>


### PR DESCRIPTION
- 기본 라우트 생성 및 로그인 전/후 상태 관련 디렉토리 분리
```
(afterLogin) // 로그인 후
- [username] // 유저 개인별 페이지
- compose // 트윗 작성하기
- explore // 둘러보기
- home // 메인
- messages // 메시지
- search // 검색

(beforeLogin) // 로그인 전
- i
  - flow
    - login
    - signup 
```

- 각 라우트 내 page.tsx 작성 및 slug 있는 경우 화면에서 확인