### PR TITLE
[style] create web/mobile layout for post-login pages

### DIFF
--- a/src/app/(afterLogin)/_component/FollowRecommend.tsx
+++ b/src/app/(afterLogin)/_component/FollowRecommend.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import style from "./followRecommend.module.css";
+
+export default function FollowRecommend() {
+  const onFollow = () => {};
+
+  const user = {
+    id: "elonmusk",
+    nickname: "Elon Musk",
+    image: "/yRsRRjGO.jpg",
+  };
+
+  return (
+    <div className={style.container}>
+      <div className={style.userLogoSection}>
+        <div className={style.userLogo}>
+          <img src={user.image} alt={user.id} />
+        </div>
+      </div>
+      <div className={style.userInfo}>
+        <div className={style.title}>{user.nickname}</div>
+        <div className={style.count}>@{user.id}</div>
+      </div>
+      <div className={style.followButtonSection}>
+        <button onClick={onFollow}>팔로우</button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/_component/LogoutButton.tsx
+++ b/src/app/(afterLogin)/_component/LogoutButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import style from "./logoutButton.module.css";
+
+export default function LogoutButton() {
+  const me = {
+    // 임시로 내 정보 있는것처럼
+    id: "zerohch0",
+    nickname: "제로초",
+    image: "/IMG_0426.jpg",
+  };
+
+  const onLogout = () => {};
+
+  return (
+    <button className={style.logOutButton} onClick={onLogout}>
+      <div className={style.logOutUserImage}>
+        <img src={me.image} alt={me.id} />
+      </div>
+      <div className={style.logOutUserName}>
+        <div>{me.nickname}</div>
+        <div>@{me.id}</div>
+      </div>
+    </button>
+  );
+}

--- a/src/app/(afterLogin)/_component/NavMenu.tsx
+++ b/src/app/(afterLogin)/_component/NavMenu.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import Link from "next/link";
+import { useSelectedLayoutSegment } from "next/navigation";
+
+// style
+import style from "./navMenu.module.css";
+
+export default function NavMenu() {
+  const segment = useSelectedLayoutSegment();
+  const me = {
+    // 임시로 내 정보 있는것처럼
+    id: "yskangg",
+  };
+
+  return (
+    <>
+      <li>
+        <Link href="/home">
+          <div className={style.navPill}>
+            {segment === "home" ? (
+              <>
+                <svg
+                  width={26}
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  className="r-18jsvk2 r-4qtqp9 r-yyyyoo r-lwhw9o r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-cnnz9e"
+                >
+                  <g>
+                    <path d="M12 1.696L.622 8.807l1.06 1.696L3 9.679V19.5C3 20.881 4.119 22 5.5 22h13c1.381 0 2.5-1.119 2.5-2.5V9.679l1.318.824 1.06-1.696L12 1.696zM12 16.5c-1.933 0-3.5-1.567-3.5-3.5s1.567-3.5 3.5-3.5 3.5 1.567 3.5 3.5-1.567 3.5-3.5 3.5z"></path>
+                  </g>
+                </svg>
+                <div className={style.activeMenuTitle}>홈</div>
+              </>
+            ) : (
+              <>
+                <svg
+                  width={26}
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  className="r-18jsvk2 r-4qtqp9 r-yyyyoo r-lwhw9o r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-cnnz9e"
+                >
+                  <g>
+                    <path d="M12 9c-2.209 0-4 1.791-4 4s1.791 4 4 4 4-1.791 4-4-1.791-4-4-4zm0 6c-1.105 0-2-.895-2-2s.895-2 2-2 2 .895 2 2-.895 2-2 2zm0-13.304L.622 8.807l1.06 1.696L3 9.679V19.5C3 20.881 4.119 22 5.5 22h13c1.381 0 2.5-1.119 2.5-2.5V9.679l1.318.824 1.06-1.696L12 1.696zM19 19.5c0 .276-.224.5-.5.5h-13c-.276 0-.5-.224-.5-.5V8.429l7-4.375 7 4.375V19.5z"></path>
+                  </g>
+                </svg>
+                <div className={style.menuTitle}>홈</div>
+              </>
+            )}
+          </div>
+        </Link>
+      </li>
+      <li>
+        <Link href="/explore">
+          <div className={style.navPill}>
+            {segment && ["search", "explore"].includes(segment) ? (
+              <>
+                <svg
+                  width={26}
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  className="r-18jsvk2 r-4qtqp9 r-yyyyoo r-lwhw9o r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-cnnz9e"
+                >
+                  <g>
+                    <path d="M10.25 4.25c-3.314 0-6 2.686-6 6s2.686 6 6 6c1.657 0 3.155-.67 4.243-1.757 1.087-1.088 1.757-2.586 1.757-4.243 0-3.314-2.686-6-6-6zm-9 6c0-4.971 4.029-9 9-9s9 4.029 9 9c0 1.943-.617 3.744-1.664 5.215l4.475 4.474-2.122 2.122-4.474-4.475c-1.471 1.047-3.272 1.664-5.215 1.664-4.971 0-9-4.029-9-9z"></path>
+                  </g>
+                </svg>
+                <div className={style.activeMenuTitle}>탐색하기</div>
+              </>
+            ) : (
+              <>
+                <svg
+                  width={26}
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  className="r-18jsvk2 r-4qtqp9 r-yyyyoo r-lwhw9o r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-cnnz9e"
+                >
+                  <g>
+                    <path d="M10.25 3.75c-3.59 0-6.5 2.91-6.5 6.5s2.91 6.5 6.5 6.5c1.795 0 3.419-.726 4.596-1.904 1.178-1.177 1.904-2.801 1.904-4.596 0-3.59-2.91-6.5-6.5-6.5zm-8.5 6.5c0-4.694 3.806-8.5 8.5-8.5s8.5 3.806 8.5 8.5c0 1.986-.682 3.815-1.824 5.262l4.781 4.781-1.414 1.414-4.781-4.781c-1.447 1.142-3.276 1.824-5.262 1.824-4.694 0-8.5-3.806-8.5-8.5z"></path>
+                  </g>
+                </svg>
+                <div className={style.menuTitle}>탐색하기</div>
+              </>
+            )}
+          </div>
+        </Link>
+      </li>
+      <li>
+        <Link href="/messages">
+          <div className={style.navPill}>
+            {segment === "messages" ? (
+              <>
+                <svg
+                  width={26}
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  className="r-18jsvk2 r-4qtqp9 r-yyyyoo r-lwhw9o r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-cnnz9e"
+                >
+                  <g>
+                    <path d="M1.998 4.499c0-.828.671-1.499 1.5-1.499h17c.828 0 1.5.671 1.5 1.499v2.858l-10 4.545-10-4.547V4.499zm0 5.053V19.5c0 .828.671 1.5 1.5 1.5h17c.828 0 1.5-.672 1.5-1.5V9.554l-10 4.545-10-4.547z"></path>
+                  </g>
+                </svg>
+                <div className={style.activeMenuTitle}>쪽지</div>
+              </>
+            ) : (
+              <>
+                <svg
+                  width={26}
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  className="r-18jsvk2 r-4qtqp9 r-yyyyoo r-lwhw9o r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-cnnz9e"
+                >
+                  <g>
+                    <path d="M1.998 5.5c0-1.381 1.119-2.5 2.5-2.5h15c1.381 0 2.5 1.119 2.5 2.5v13c0 1.381-1.119 2.5-2.5 2.5h-15c-1.381 0-2.5-1.119-2.5-2.5v-13zm2.5-.5c-.276 0-.5.224-.5.5v2.764l8 3.638 8-3.636V5.5c0-.276-.224-.5-.5-.5h-15zm15.5 5.463l-8 3.636-8-3.638V18.5c0 .276.224.5.5.5h15c.276 0 .5-.224.5-.5v-8.037z"></path>
+                  </g>
+                </svg>
+                <div className={style.menuTitle}>쪽지</div>
+              </>
+            )}
+          </div>
+        </Link>
+      </li>
+      {me?.id && (
+        <li>
+          <Link href={`/${me?.id}`}>
+            <div className={style.navPill}>
+              {segment === me.id ? (
+                <>
+                  <svg
+                    width={26}
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    className="r-18jsvk2 r-4qtqp9 r-yyyyoo r-lwhw9o r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-cnnz9e"
+                  >
+                    <g>
+                      <path d="M17.863 13.44c1.477 1.58 2.366 3.8 2.632 6.46l.11 1.1H3.395l.11-1.1c.266-2.66 1.155-4.88 2.632-6.46C7.627 11.85 9.648 11 12 11s4.373.85 5.863 2.44zM12 2C9.791 2 8 3.79 8 6s1.791 4 4 4 4-1.79 4-4-1.791-4-4-4z"></path>
+                    </g>
+                  </svg>
+                  <div className={style.activeMenuTitle}>프로필</div>
+                </>
+              ) : (
+                <>
+                  <svg
+                    width={26}
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    className="r-18jsvk2 r-4qtqp9 r-yyyyoo r-lwhw9o r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-cnnz9e"
+                  >
+                    <g>
+                      <path d="M5.651 19h12.698c-.337-1.8-1.023-3.21-1.945-4.19C15.318 13.65 13.838 13 12 13s-3.317.65-4.404 1.81c-.922.98-1.608 2.39-1.945 4.19zm.486-5.56C7.627 11.85 9.648 11 12 11s4.373.85 5.863 2.44c1.477 1.58 2.366 3.8 2.632 6.46l.11 1.1H3.395l.11-1.1c.266-2.66 1.155-4.88 2.632-6.46zM12 4c-1.105 0-2 .9-2 2s.895 2 2 2 2-.9 2-2-.895-2-2-2zM8 6c0-2.21 1.791-4 4-4s4 1.79 4 4-1.791 4-4 4-4-1.79-4-4z"></path>
+                    </g>
+                  </svg>
+                  <div className={style.menuTitle}>프로필</div>
+                </>
+              )}
+            </div>
+          </Link>
+        </li>
+      )}
+    </>
+  );
+}

--- a/src/app/(afterLogin)/_component/PostButton.tsx
+++ b/src/app/(afterLogin)/_component/PostButton.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import Link from "next/link";
+
+import style from "./postButton.module.css";
+
+const PostButton = () => {
+  return (
+    <Link href="/compose/tweet" className={style.postButton}>
+      <svg
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className="r-4qtqp9 r-yyyyoo r-dnmrzs r-bnwqim r-lrvibr r-m6rgpd r-1472mwg r-lrsllp"
+      >
+        <g>
+          <path d="M23 3c-6.62-.1-10.38 2.421-13.05 6.03C7.29 12.61 6 17.331 6 22h2c0-1.007.07-2.012.19-3H12c4.1 0 7.48-3.082 7.94-7.054C22.79 10.147 23.17 6.359 23 3zm-7 8h-1.5v2H16c.63-.016 1.2-.08 1.72-.188C16.95 15.24 14.68 17 12 17H8.55c.57-2.512 1.57-4.851 3-6.78 2.16-2.912 5.29-4.911 9.45-5.187C20.95 8.079 19.9 11 16 11zM4 9V6H1V4h3V1h2v3h3v2H6v3H4z"></path>
+        </g>
+      </svg>
+      <p>게시하기</p>
+    </Link>
+  );
+};
+
+export default PostButton;

--- a/src/app/(afterLogin)/_component/Trend.tsx
+++ b/src/app/(afterLogin)/_component/Trend.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+// style
+import style from "./trend.module.css";
+
+export default function Trend() {
+  return (
+    <Link href={`/search?q=트렌드`} className={style.container}>
+      <div className={style.count}>실시간트렌드</div>
+      <div className={style.title}>제로초</div>
+      <div className={style.count}>1,234 posts</div>
+    </Link>
+  );
+}

--- a/src/app/(afterLogin)/_component/TrendSection.tsx
+++ b/src/app/(afterLogin)/_component/TrendSection.tsx
@@ -1,0 +1,22 @@
+import style from "./trendSection.module.css";
+import Trend from "@/app/(afterLogin)/_component/Trend";
+
+export default function TrendSection() {
+  return (
+    <div className={style.trendBg}>
+      <div className={style.trend}>
+        <h3>나를 위한 트렌드</h3>
+        <Trend />
+        <Trend />
+        <Trend />
+        <Trend />
+        <Trend />
+        <Trend />
+        <Trend />
+        <Trend />
+        <Trend />
+        <Trend />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/_component/followRecommend.module.css
+++ b/src/app/(afterLogin)/_component/followRecommend.module.css
@@ -1,0 +1,52 @@
+.container {
+  padding: 12px 0;
+  height: 66px;
+  display: flex;
+}
+
+.userLogo {
+  width: 40px;
+  margin-right: 12px;
+}
+
+.userLogo,
+.userLogo img {
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
+}
+
+.userInfo {
+  flex: 1;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: bold;
+  line-height: 20px;
+}
+
+.count {
+  color: rgb(83, 100, 113);
+  font-size: 13px;
+  line-height: 16px;
+}
+
+.followButtonSection {
+  width: 76px;
+}
+
+.followButtonSection button {
+  border: none;
+  cursor: pointer;
+  width: 100%;
+  color: white;
+  background: #000;
+  font-size: 14px;
+  font-weight: bold;
+  height: 32px;
+  border-radius: 16px;
+}
+.followButtonSection button:hover {
+  background-color: rgb(39, 44, 48);
+}

--- a/src/app/(afterLogin)/_component/logoutButton.module.css
+++ b/src/app/(afterLogin)/_component/logoutButton.module.css
@@ -1,0 +1,40 @@
+.logOutButton {
+  width: 258px;
+  height: 66px;
+  padding: 12px;
+  display: flex;
+  margin: 12px 0;
+  cursor: pointer;
+  border: none;
+  align-items: center;
+  background-color: #fff;
+  text-align: left;
+}
+.logOutButton:hover {
+  background-color: rgba(15, 20, 25, 0.1);
+  border-radius: 33px;
+}
+.logOutUserImage {
+  display: flex;
+  align-items: center;
+}
+.logOutUserImage img {
+  width: 40px;
+  border-radius: 50%;
+}
+.logOutUserName {
+  margin: 0 12px;
+}
+.logOutUserName > div:first-child {
+  font-weight: bold;
+}
+
+/* 📌 1295px 이하일 때 텍스트 숨기기 */
+@media (max-width: 1295px) {
+  .logOutButton {
+    width: 66px;
+  }
+  .logOutUserName {
+    display: none; /* 텍스트 숨김 */
+  }
+}

--- a/src/app/(afterLogin)/_component/navMenu.module.css
+++ b/src/app/(afterLogin)/_component/navMenu.module.css
@@ -1,0 +1,28 @@
+.navPill {
+  display: inline-flex;
+  height: 50px;
+  padding: 12px;
+  align-items: center;
+}
+.navPill:hover {
+  background-color: rgba(15, 20, 25, 0.1);
+  border-radius: 29px;
+}
+
+.navPill > div {
+  margin-left: 20px;
+  margin-right: 16px;
+  font-size: 20px;
+}
+
+.activeMenuTitle {
+  font-weight: bold;
+}
+
+/* 📌 1295px 이하일 때 nav ul 내 텍스트 숨기기 */
+@media (max-width: 1295px) {
+  .activeMenuTitle,
+  .menuTitle {
+    display: none; /* 텍스트 숨김 */
+  }
+}

--- a/src/app/(afterLogin)/_component/postButton.module.css
+++ b/src/app/(afterLogin)/_component/postButton.module.css
@@ -1,0 +1,40 @@
+.postButton {
+  margin: 16px 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 52px;
+  box-shadow: rgba(0, 0, 0, 0.08) 0px 8px 28px;
+  background-color: rgb(29, 155, 240);
+  width: 234px;
+  border: none;
+  color: rgb(255, 255, 255);
+  font-weight: 700;
+  font-size: 17px;
+  border-radius: 26px;
+}
+
+.postButton:hover {
+  background-color: rgb(26, 140, 216);
+}
+
+.postButton svg {
+  width: 30px;
+  height: 30px;
+  display: none;
+}
+
+@media (max-width: 1295px) {
+  .postButton {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    margin: 30px auto 0;
+  }
+  .postButton svg {
+    display: block;
+  }
+  .postButton p {
+    display: none;
+  }
+}

--- a/src/app/(afterLogin)/_component/trend.module.css
+++ b/src/app/(afterLogin)/_component/trend.module.css
@@ -1,0 +1,23 @@
+.container {
+  padding: 12px 16px;
+  height: 82px;
+  display: block;
+}
+.container:hover {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+.title {
+  font-size: 15px;
+  font-weight: bold;
+  line-height: 20px;
+  margin-top: 2px;
+  margin-bottom: 4px;
+}
+
+.count {
+  color: rgb(83, 100, 113);
+  font-size: 13px;
+  line-height: 16px;
+  font-weight: lighter;
+}

--- a/src/app/(afterLogin)/_component/trendSection.module.css
+++ b/src/app/(afterLogin)/_component/trendSection.module.css
@@ -1,0 +1,14 @@
+.trendBg {
+  background-color: rgb(247, 249, 249);
+  border-radius: 16px;
+  margin-top: 12px;
+}
+.trend {
+  font-size: 20px;
+  font-weight: bold;
+  padding: 12px 0;
+}
+.trend h3 {
+  margin-bottom: 12px;
+  padding: 0 16px;
+}

--- a/src/app/(afterLogin)/layout.module.css
+++ b/src/app/(afterLogin)/layout.module.css
@@ -1,0 +1,170 @@
+.container {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  background-color: #fff;
+}
+
+/* 좌측 사이드바 */
+.leftSectionWrapper {
+  display: flex;
+  align-items: flex-end;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.leftSection {
+  width: 275px;
+  height: 100dvh;
+}
+
+.leftSectionFixed {
+  position: fixed;
+  width: inherit;
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  border-top: none;
+  border-right: 1px solid rgb(239, 243, 244);
+  border-bottom: none;
+  border-left: none;
+}
+
+.leftSectionFixed nav {
+  flex: 1;
+}
+.leftSectionFixed nav li {
+  list-style-type: none;
+}
+
+.logo {
+  display: inline-block;
+  height: 56px;
+  margin-top: 2px;
+}
+
+.logoPill {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.logoPill:hover {
+  background-color: rgba(15, 20, 25, 0.1);
+}
+
+/* 중앙 피드 영역 및 우측 사이드 영역 */
+.rightSectionWrapper {
+  display: flex;
+  align-items: flex-start;
+  height: 100dvh;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.rightSectionInner {
+  height: 100%;
+  width: 990px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.main {
+  width: 600px;
+  height: 200dvh;
+  border-top: none;
+  border-right: 1px solid rgb(239, 243, 244);
+  border-bottom: none; /* 필요 없다면 없애기 */
+  border-left: none;
+}
+
+.rightSection {
+  width: 350px;
+  height: 100%;
+}
+
+.search {
+  position: fixed;
+  height: 42px;
+  width: inherit;
+  border-radius: 21px;
+  background-color: rgb(239, 243, 244);
+  margin-top: 6px;
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+}
+
+.search svg {
+  margin-left: 20px;
+  fill: rgb(83, 100, 113);
+}
+
+.search input {
+  outline: none;
+  background-color: inherit;
+  border: none;
+  padding: 12px;
+  margin-left: 5px;
+  font-size: 15px;
+}
+
+.followRecommend {
+  font-size: 20px;
+  font-weight: bold;
+  background-color: rgb(247, 249, 249);
+  border-radius: 16px;
+  margin: 12px 0;
+  padding: 12px 16px;
+}
+
+.followRecommend h3 {
+  padding-bottom: 12px;
+}
+
+/* 📌 1295px 이하일 때 leftSection width 줄어듬 */
+@media (max-width: 1295px) {
+  .leftSection {
+    width: 88px;
+  }
+
+  .leftSectionFixed {
+    align-items: center;
+  }
+
+  .leftSectionFixed nav {
+    width: 100%;
+  }
+
+  .leftSectionFixed nav li {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .leftSectionFixed nav li a {
+    display: inline-block;
+  }
+}
+
+/* 📌 1018px 이하일 때 오른쪽 섹션 숨김 */
+@media (max-width: 1080px) {
+  .rightSection {
+    display: none;
+  }
+  .rightSectionInner {
+    width: auto;
+  }
+}
+
+@media (max-width: 700px) {
+  .rightSectionWrapper {
+    width: calc(100% - 88px);
+  }
+
+  .rightSectionInner {
+    width: 100%;
+  }
+}

--- a/src/app/(afterLogin)/layout.tsx
+++ b/src/app/(afterLogin)/layout.tsx
@@ -6,6 +6,8 @@ import Image from "next/image";
 import NavMenu from "./_component/NavMenu";
 import LogoutButton from "./_component/LogoutButton";
 import PostButton from "./_component/PostButton";
+import FollowRecommend from "./_component/FollowRecommend";
+import TrendSection from "./_component/TrendSection";
 
 // style
 import style from "@/app/(afterLogin)/layout.module.css";
@@ -50,8 +52,12 @@ export default function AfterLoginLayout({ children }: Props) {
                 <input type="search" />
               </form>
             </div>
+            <TrendSection />
             <div className={style.followRecommend}>
               <h3>팔로우 추천</h3>
+              <FollowRecommend />
+              <FollowRecommend />
+              <FollowRecommend />
             </div>
           </section>
         </div>

--- a/src/app/(afterLogin)/layout.tsx
+++ b/src/app/(afterLogin)/layout.tsx
@@ -1,4 +1,17 @@
 import { ReactNode } from "react";
+import Link from "next/link";
+import Image from "next/image";
+
+// component
+import NavMenu from "./_component/NavMenu";
+import LogoutButton from "./_component/LogoutButton";
+import PostButton from "./_component/PostButton";
+
+// style
+import style from "@/app/(afterLogin)/layout.module.css";
+
+// img
+import ZLogo from "../../../public/zlogo.png";
 
 type Props = {
   children: ReactNode;
@@ -6,9 +19,43 @@ type Props = {
 
 export default function AfterLoginLayout({ children }: Props) {
   return (
-    <div>
-      애프터 로그인 레이아웃
-      {children}
+    <div className={style.container}>
+      <header className={style.leftSectionWrapper}>
+        <section className={style.leftSection}>
+          <div className={style.leftSectionFixed}>
+            <Link className={style.logo} href="/home">
+              <div className={style.logoPill}>
+                <Image src={ZLogo} alt="z.com로고" width={40} height={40} />
+              </div>
+            </Link>
+            <nav>
+              <NavMenu />
+              <PostButton />
+            </nav>
+            <LogoutButton />
+          </div>
+        </section>
+      </header>
+      <div className={style.rightSectionWrapper}>
+        <div className={style.rightSectionInner}>
+          <main className={style.main}>{children}</main>
+          <section className={style.rightSection}>
+            <div style={{ marginBottom: 60, width: "inherit" }}>
+              <form className={style.search}>
+                <svg width={20} viewBox="0 0 24 24" aria-hidden="true">
+                  <g>
+                    <path d="M10.25 3.75c-3.59 0-6.5 2.91-6.5 6.5s2.91 6.5 6.5 6.5c1.795 0 3.419-.726 4.596-1.904 1.178-1.177 1.904-2.801 1.904-4.596 0-3.59-2.91-6.5-6.5-6.5zm-8.5 6.5c0-4.694 3.806-8.5 8.5-8.5s8.5 3.806 8.5 8.5c0 1.986-.682 3.815-1.824 5.262l4.781 4.781-1.414 1.414-4.781-4.781c-1.447 1.142-3.276 1.824-5.262 1.824-4.694 0-8.5-3.806-8.5-8.5z"></path>
+                  </g>
+                </svg>
+                <input type="search" />
+              </form>
+            </div>
+            <div className={style.followRecommend}>
+              <h3>팔로우 추천</h3>
+            </div>
+          </section>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- 로그인 이후 화면에서 사용될 layout 뼈대/기본 컴포넌트 작성
- 현 'x'의 화면을 참고해서 웹/모바일 css 작성
- Next.js의 `useSelectedLayoutSegment`를 사용해서 현 화면의 위치 파악: react였다면 useParams 같은 훅을 사용해서 '/'를 제거하고 중첩된 위치를 찾아내는데 가공이 필요했을 텐데, useSelectedLayoutSegment를 사용해서 한번에 알아낼 수 있다는게 편리하다고 느껴짐