### PR TITLE
[feature] creating modal, layout and page for 'compose/tweet'

### DIFF
--- a/src/app/(afterLogin)/@modal/(.)compose/tweet/modal.module.css
+++ b/src/app/(afterLogin)/@modal/(.)compose/tweet/modal.module.css
@@ -1,0 +1,145 @@
+.modalBackground {
+  width: 100vw;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  position: absolute;
+  z-index: 10;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+}
+.modal {
+  background: #ffffff;
+  position: relative;
+  top: 5%;
+  max-width: 80vw;
+  min-width: 600px;
+  max-height: 400px;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+}
+
+.closeButton {
+  width: 34px;
+  height: 34px;
+  border-radius: 17px;
+  border: none;
+  cursor: pointer;
+  background-color: #fff;
+  position: absolute;
+  left: 8px;
+  top: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.closeButton:hover {
+  background-color: rgba(15, 20, 25, 0.1);
+}
+
+.modalForm {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.modalBody {
+  padding: 0 16px;
+  flex: 1;
+  margin-top: 54px;
+  display: flex;
+  flex-direction: row;
+}
+
+.postUserSection {
+  margin-right: 12px;
+  width: 40px;
+}
+
+.postUserImage {
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
+}
+
+.postUserImage img {
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
+}
+
+.inputDiv {
+  flex: 1;
+}
+
+.input {
+  width: 100%;
+  border: none;
+  outline: none;
+  font-size: 20px;
+}
+.input::placeholder {
+  font-family: "Malgun Gothic", sans-serif;
+}
+
+.modalFooter {
+  padding: 0 16px;
+}
+
+.modalDivider {
+  width: 100%;
+  border-bottom: 1px solid rgb(239, 243, 244);
+}
+.footerButtons {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+.footerButtonLeft {
+  flex: 1;
+}
+
+.uploadButton {
+  width: 34px;
+  height: 34px;
+  border: none;
+  cursor: pointer;
+  border-radius: 17px;
+  background-color: rgb(29, 155, 240, 0.01);
+  transition-duration: 0.2s;
+  transition-property: background-color;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.uploadButton:hover {
+  background-color: rgb(29, 155, 240, 0.1);
+}
+.uploadButton svg {
+  fill: rgb(29, 155, 240);
+}
+
+.actionButton {
+  cursor: pointer;
+  width: 94px;
+  height: 36px;
+  border-radius: 18px;
+  border: none;
+  margin: 8px 0;
+  background-color: rgb(29, 155, 240);
+  color: white;
+  font-size: 17px;
+}
+.actionButton:disabled {
+  opacity: 0.5;
+}
+
+@media (max-width: 700px) {
+  .modal {
+    min-width: auto;
+  }
+}

--- a/src/app/(afterLogin)/@modal/(.)compose/tweet/page.tsx
+++ b/src/app/(afterLogin)/@modal/(.)compose/tweet/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+// style
+import style from "./modal.module.css";
+
+export default function TweetModal() {
+  const [content, setContent] = useState();
+  const router = useRouter();
+  const imageRef = useRef<HTMLInputElement>(null);
+  const onClickButton = () => {};
+  const onClickClose = () => {
+    router.back();
+  };
+  const onChangeContent = () => {};
+  const onSubmit = () => {};
+
+  const me = {
+    id: "yskangg",
+    image: "/IMG_0426.jpeg",
+  };
+
+  return (
+    <div className={style.modalBackground}>
+      <div className={style.modal}>
+        <button className={style.closeButton} onClick={onClickClose}>
+          <svg
+            width={24}
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            className="r-18jsvk2 r-4qtqp9 r-yyyyoo r-z80fyv r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-19wmn03"
+          >
+            <g>
+              <path d="M10.59 12L4.54 5.96l1.42-1.42L12 10.59l6.04-6.05 1.42 1.42L13.41 12l6.05 6.04-1.42 1.42L12 13.41l-6.04 6.05-1.42-1.42L10.59 12z"></path>
+            </g>
+          </svg>
+        </button>
+        <form className={style.modalForm} onSubmit={onSubmit}>
+          <div className={style.modalBody}>
+            <div className={style.postUserSection}>
+              <div className={style.postUserImage}>
+                <img src={me.image} alt={me.id} />
+              </div>
+            </div>
+            <div className={style.inputDiv}>
+              <textarea
+                className={style.input}
+                placeholder="무슨 일이 일어나고 있나요?"
+                value={content}
+                onChange={onChangeContent}
+              />
+            </div>
+          </div>
+          <div className={style.modalFooter}>
+            <div className={style.modalDivider} />
+            <div className={style.footerButtons}>
+              <div className={style.footerButtonLeft}>
+                <input
+                  type="file"
+                  name="imageFiles"
+                  multiple
+                  hidden
+                  ref={imageRef}
+                />
+                <button
+                  className={style.uploadButton}
+                  type="button"
+                  onClick={onClickButton}
+                >
+                  <svg width={24} viewBox="0 0 24 24" aria-hidden="true">
+                    <g>
+                      <path d="M3 5.5C3 4.119 4.119 3 5.5 3h13C19.881 3 21 4.119 21 5.5v13c0 1.381-1.119 2.5-2.5 2.5h-13C4.119 21 3 19.881 3 18.5v-13zM5.5 5c-.276 0-.5.224-.5.5v9.086l3-3 3 3 5-5 3 3V5.5c0-.276-.224-.5-.5-.5h-13zM19 15.414l-3-3-5 5-3-3-3 3V18.5c0 .276.224.5.5.5h13c.276 0 .5-.224.5-.5v-3.086zM9.75 7C8.784 7 8 7.784 8 8.75s.784 1.75 1.75 1.75 1.75-.784 1.75-1.75S10.716 7 9.75 7z"></path>
+                    </g>
+                  </svg>
+                </button>
+              </div>
+              <button className={style.actionButton} disabled={!content}>
+                게시하기
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/@modal/default.tsx
+++ b/src/app/(afterLogin)/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/(afterLogin)/compose/tweet/page.tsx
+++ b/src/app/(afterLogin)/compose/tweet/page.tsx
@@ -1,8 +1,5 @@
-export default function TweetPage() {
-  return (
-    <div style={{ padding: "2rem" }}>
-      <h1>compose tweet Page</h1>
-      <p>여기는 트윗 작성 페이지입니다.</p>
-    </div>
-  );
+import Home from "@/app/(afterLogin)/home/page";
+
+export default function Page() {
+  return <Home />;
 }

--- a/src/app/(afterLogin)/layout.tsx
+++ b/src/app/(afterLogin)/layout.tsx
@@ -17,9 +17,10 @@ import ZLogo from "../../../public/zlogo.png";
 
 type Props = {
   children: ReactNode;
+  modal: ReactNode;
 };
 
-export default function AfterLoginLayout({ children }: Props) {
+export default function AfterLoginLayout({ children, modal }: Props) {
   return (
     <div className={style.container}>
       <header className={style.leftSectionWrapper}>
@@ -62,6 +63,7 @@ export default function AfterLoginLayout({ children }: Props) {
           </section>
         </div>
       </div>
+      {modal}
     </div>
   );
 }


### PR DESCRIPTION
- 트윗 작성 모달 @modal 작성 및 반응형 레이아웃 작업
  - useRouter 활용한 트윗 작성 모달 내 닫기 버튼 기능 작성 
  - 추후 이 부분도 합성 컴포넌트 패턴으로 분리 가능 할듯 (추가적으로 확장이 된다면)
- intercepting routes를 통해 '/home'화면 유지하면서 트윗 작성 모달('compose/tweet') 노출 